### PR TITLE
Added an onScroll event that will disable justHitEnter.

### DIFF
--- a/app/containers/home.jsx
+++ b/app/containers/home.jsx
@@ -44,6 +44,7 @@ export class Home extends Component {
       <Messages username={this.props.username}
         justHitEnter={this.state.justHitEnter}
         messages={this.props.messages}
+        changeEnterStatus={this.changeEnterStatus}
         inventory={this.props.inventory} />
       <Prompt character={this.props.character} />
       <CommandInput

--- a/app/containers/messages.jsx
+++ b/app/containers/messages.jsx
@@ -46,7 +46,7 @@ export default class Messages extends Component {
         {message.inventory ? <Inventory inventory={message.inventory}/> : null}
       </li>;
     });
-    return <div ref={messageList => this.messageList = messageList} className="messages">
+    return <div ref={messageList => this.messageList = messageList} onScroll={() => this.props.changeEnterStatus(false)} className="messages">
       <ul>{messages}</ul>
     </div>;
   }
@@ -55,5 +55,6 @@ export default class Messages extends Component {
 Messages.propTypes = {
   messages: PropTypes.array,
   justHitEnter: PropTypes.bool,
-  username: PropTypes.string
+  username: PropTypes.string,
+  changeEnterStatus: PropTypes.func
 };


### PR DESCRIPTION
The issue was that justHitEnter was set to true after entering a command (as intended), but it was not toggled back to false until the user triggered a component update by entering more input. Now scrolling the messages container will also toggle it to false, giving the desired behavior.